### PR TITLE
Updates & Upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --update --no-cache libc6-compat wget tar && \
     wget https://artifacts.elastic.co/downloads/beats/filebeat/$PACKAGE && \
     tar --strip-components=1 -zxf /opt/filebeat/"$PACKAGE" && \
     rm -f "$PACKAGE" && \
-    wget -P /etc/pki/tls/certs/ https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt && \
+    wget -P /etc/pki/tls/certs/ https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt && \
     pip3 install -r ./docker-colletor-logs/requirements.txt --user && \
     rm -f ./docker-colletor-logs/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine
 
-ENV PACKAGE=filebeat-7.8.1-linux-x86_64.tar.gz
+ENV PACKAGE=filebeat-7.9.0-linux-x86_64.tar.gz
 
 
 RUN mkdir -p /opt/filebeat/docker-colletor-logs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine
 
-ENV PACKAGE=filebeat-6.5.4-linux-x86_64.tar.gz
+ENV PACKAGE=filebeat-7.8.1-linux-x86_64.tar.gz
 
 
 RUN mkdir -p /opt/filebeat/docker-colletor-logs && \

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Spin up your Docker containers if you haven’t done so already. Give your logs 
 
 ### Change log
 - 0.1.0:
-    - Upgrade to Filebeat 7.8.1.
-    - Update default_filebeat.yml configuration to match newer version.
+    - Upgrade to Filebeat 7.9.0.
+    - Update default_filebeat.yml configuration to match newer Filebeat version.
     - Support adding hostname.
     - Deprecated `LOGZIO_URL`. Use `LOGZIO_REGION` instead.
 - 0.0.6: Updated new public SSL certificate in Docker image & Filebeat configuration.

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ Spin up your Docker containers if you haven’t done so already. Give your logs 
 
 ### Change log
 - 0.1.0:
-    - **BREAKING CHANGES**: Upgrade to Filebeat 7.9.0.
+    - **BREAKING CHANGES**:
+        - Upgrade to Filebeat 7.9.0.
+        - Deprecated `LOGZIO_URL`. Use `LOGZIO_REGION` instead.
     - Update default_filebeat.yml configuration to match newer Filebeat version.
     - Support adding hostname.
-    - Deprecated `LOGZIO_URL`. Use `LOGZIO_REGION` instead.
 - 0.0.6: Updated new public SSL certificate in Docker image & Filebeat configuration.
 - 0.0.4: Added options to include or exclude lines
 - 0.0.3: Support additional fields

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Spin up your Docker containers if you haven’t done so already. Give your logs 
 
 ### Change log
 - 0.1.0:
-    - Upgrade to Filebeat 7.9.0.
+    - **BREAKING CHANGES**: Upgrade to Filebeat 7.9.0.
     - Update default_filebeat.yml configuration to match newer Filebeat version.
     - Support adding hostname.
     - Deprecated `LOGZIO_URL`. Use `LOGZIO_REGION` instead.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ docker-collector-logs mounts docker.sock and the Docker logs directory to the co
 docker-collector-logs ships logs only.
 If you want to ship metrics to Logz.io, see [docker-collector-metrics](https://github.com/logzio/docker-collector-metrics).
 
-**Note:** Upgrading to a newer version of a docker-collector-logs while it is already running will cause it to resend logs that are within the `ignoreOlder` timeframe. You can minimize log duplicates by setting the `ignoreOlder` parameter of the new docker to a lower value (for example, `20m`.
+**Note:** Upgrading to a newer version of a docker-collector-logs while it is already running will cause it to resend logs that are within the `ignoreOlder` timeframe. You can minimize log duplicates by setting the `ignoreOlder` parameter of the new docker to a lower value (for example, `20m`).
 
 ## docker-collector-logs setup
 
@@ -28,7 +28,6 @@ For a complete list of options, see the parameters below the code block.👇
 ```shell
 docker run --name docker-collector-logs \
 --env LOGZIO_TOKEN="<ACCOUNT-TOKEN>" \
---env LOGZIO_URL="<LISTENER-URL>:5015" \
 -v /var/run/docker.sock:/var/run/docker.sock:ro \
 -v /var/lib/docker/containers:/var/lib/docker/containers \
 logzio/docker-collector-logs
@@ -39,7 +38,7 @@ logzio/docker-collector-logs
 | Parameter | Description |
 |---|---|
 | **LOGZIO_TOKEN** | **Required**. Your Logz.io account token. Replace `<ACCOUNT-TOKEN>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the account you want to ship to. |
-| **LOGZIO_URL** | **Required**. Logz.io listener URL to ship the logs to. This URL changes depending on the region your account is hosted in. For example, accounts in the US region ship to `listener.logz.io`, and accounts in the EU region ship to `listener-eu.logz.io`. <br /> For more information, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html) on the Logz.io Docs. |
+| **LOGZIO_REGION** | **Default**: US region.<br> Logz.io region code to ship the logs to. This region code changes depending on the region your account is hosted in. For example, accounts in the EU region have region code `eu`.<br /> For more information, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html) on the Logz.io Docs. |
 | **LOGZIO_TYPE** | **Default**: Docker image name <br> The log type you'll use with this Docker. This is shown in your logs under the `type` field in Kibana. <br> Logz.io applies parsing based on `type`. |
 | **LOGZIO_CODEC** | **Default**: `plain`<br> Set to `json` if shipping JSON logs. Otherwise, set to `plain`. |
 | **matchContainerName** | Comma-separated list of containers you want to collect the logs from. If a container's name partially matches a name on the list, that container's logs are shipped. Otherwise, its logs are ignored. <br /> **Note**: Can't be used with `skipContainerName` |
@@ -48,6 +47,7 @@ logzio/docker-collector-logs
 | **excludeLines** | Comma-separated list of regular expressions to match the lines that you want Filebeat to exclude. <br /> **Note**: Does not behave well with regular expressions containing commas `,`|
 | **includeLines** | Comma-separated list of regular expressions to match the lines that you want Filebeat to include. <br /> **Note**: Does not behave well with regular expressions containing commas `,`|
 | **ignoreOlder** | **Default** `3h` <br> Logs older than this will be ignored|
+| **HOSTNAME** | **Default** `''` <br> Insert your host name if you want it to appear under the field `agent.name`. If no value entered,  `agent.name` will show the container's id.|
 
 **Note**: By default, logs from `docker-collector-logs` and `docker-collector-metrics` containers are ignored.
 
@@ -56,6 +56,11 @@ logzio/docker-collector-logs
 Spin up your Docker containers if you haven’t done so already. Give your logs a few minutes to get from your system to ours, and then open [Kibana](https://app.logz.io/#/dashboard/kibana).
 
 ### Change log
+- 0.1.0:
+    - Upgrade to Filebeat 7.8.1.
+    - Update default_filebeat.yml configuration to match newer version.
+    - Support adding hostname.
+    - Deprecated `LOGZIO_URL`. Use `LOGZIO_REGION` instead.
 - 0.0.6: Updated new public SSL certificate in Docker image & Filebeat configuration.
 - 0.0.4: Added options to include or exclude lines
 - 0.0.3: Support additional fields

--- a/default_filebeat.yml
+++ b/default_filebeat.yml
@@ -1,10 +1,9 @@
 ############################# Filebeat #####################################
 
 filebeat.inputs:
-- type: docker
-  containers:
-    path: /var/lib/docker/containers
-    ids: '*'
+- type: container
+  paths:
+    - '/var/lib/docker/containers/*/*.log'
   fields_under_root: true
   processors:
   - add_docker_metadata: ~

--- a/default_filebeat.yml
+++ b/default_filebeat.yml
@@ -17,4 +17,4 @@ output:
   logstash:
     hosts: []
     ssl:
-      certificate_authorities: [/etc/pki/tls/certs/TrustExternalCARoot_and_USERTrustRSAAAACA.crt]
+      certificate_authorities: [/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt]

--- a/filebeat-yml-script.py
+++ b/filebeat-yml-script.py
@@ -6,6 +6,7 @@ import socket
 logging.basicConfig(format='%(asctime)s\t%(levelname)s\t%(message)s', level=logging.DEBUG)
 
 # set vars and consts
+DOCKER_COLLECTOR_VERSION = "0.1.0"
 LOGZIO_LISTENER_ADDRESS = "listener.logz.io:5015"
 logzio_url = LOGZIO_LISTENER_ADDRESS
 logzio_url_arr = logzio_url.split(":")
@@ -197,11 +198,15 @@ def _get_host_name():
     return os.getenv("HOSTNAME", '')
 
 
+def _display_docker_collector_version():
+    logging.info("Using docker-collector-logs version: {}".format(DOCKER_COLLECTOR_VERSION))
+
 _set_url()
 
 HOST = logzio_url_arr[0]
 PORT = int(logzio_url_arr[1])
 
+_display_docker_collector_version()
 _is_open()
 _add_shipping_data()
 

--- a/filebeat-yml-script.py
+++ b/filebeat-yml-script.py
@@ -6,11 +6,12 @@ import socket
 logging.basicConfig(format='%(asctime)s\t%(levelname)s\t%(message)s', level=logging.DEBUG)
 
 # set vars and consts
-logzio_url = os.environ["LOGZIO_URL"]
+LOGZIO_LISTENER_ADDRESS = "listener.logz.io:5015"
+logzio_url = LOGZIO_LISTENER_ADDRESS
 logzio_url_arr = logzio_url.split(":")
 logzio_token = os.environ["LOGZIO_TOKEN"]
 logzio_type = os.getenv("LOGZIO_TYPE", "docker-collector-logs")
-
+logzio_region = os.getenv("LOGZIO_REGION", "")
 logzio_codec = os.getenv("LOGZIO_CODEC", "plain").lower()
 logzio_codec_list = ["plain", "json"]
 if logzio_codec not in logzio_codec_list:
@@ -19,11 +20,41 @@ if logzio_codec not in logzio_codec_list:
     logzio_codec = "plain"
 
 
-HOST = logzio_url_arr[0]
-PORT = int(logzio_url_arr[1])
 FILEBEAT_CONF_PATH = f"{os.getcwd()}/filebeat.yml"
 SOCKET_TIMEOUT = 3
 FIRST_CHAR = 0
+
+
+def get_listener_url(region):
+    return LOGZIO_LISTENER_ADDRESS.replace("listener.", "listener{}.".format(get_region_code(region)))
+
+
+def get_region_code(region):
+    if region != "us" and region != "":
+        return "-{}".format(region)
+    return ""
+
+
+def _set_url():
+    global logzio_url
+    global logzio_url_arr
+    region = ""
+    is_region = False
+    if 'LOGZIO_REGION' in os.environ:
+        region = os.environ['LOGZIO_REGION']
+        is_region = True
+        if 'LOGZIO_URL' in os.environ:
+            logging.warning("Both LOGZIO_REGION and LOGZIO_URL were entered! Using LOGZIO_REGION.")
+    else:
+        if 'LOGZIO_URL' in os.environ and os.environ['LOGZIO_URL'] != "":
+            logzio_url = os.environ['LOGZIO_URL']
+            logging.warning("Please note that LOGZIO_URL is deprecated! In future versions use LOGZIO_REGION.")
+        else:
+            is_region = True
+
+    if is_region:
+        logzio_url = get_listener_url(region)
+    logzio_url_arr = logzio_url.split(":")
 
 
 def _is_open():
@@ -50,6 +81,10 @@ def _add_shipping_data():
     config_dic["filebeat.inputs"][0]["fields"]["logzio_codec"] = logzio_codec
     config_dic["filebeat.inputs"][0]["fields"]["type"] = logzio_type
     config_dic["filebeat.inputs"][0]["ignore_older"] = _get_ignore_older()
+
+    hostname = _get_host_name()
+    if hostname is not '':
+        config_dic["name"] = hostname
 
     additional_field = _get_additional_fields()
     for key in additional_field:
@@ -157,7 +192,16 @@ def _include_lines():
     with open(FILEBEAT_CONF_PATH, "w+") as updated_filebeat_yml:
         yaml.dump(config_dic, updated_filebeat_yml)
 
-        
+
+def _get_host_name():
+    return os.getenv("HOSTNAME", '')
+
+
+_set_url()
+
+HOST = logzio_url_arr[0]
+PORT = int(logzio_url_arr[1])
+
 _is_open()
 _add_shipping_data()
 


### PR DESCRIPTION
* Upgraded Filebeat version from `6.5.4` to `7.8.1`.
* In `default_filebeat.yml` changed to- `type: container` because Filebeat alerted that `type: docker` is deprecated, and will be removed from version 8.0.
* Added the option to insert env `HOSTNAME`, to appear under `agent.name` (beats don't allow override of `agent.hostname`). - @Doron-Bargo FYI.
* Deprecated `LOGZIO_URL`. Users should use `LOGZIO_REGION` instead. (Right now both are acceptable, using `LOGZIO_URL` will cause a deprecation message in the logs).

@shalper Please see the changes in the readme and update them in the docs.