### PR TITLE
Upgrade to Filebeat 8.3.3, add workflow for build and push

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,92 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+      - '*'
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+       # Get the repository's code
+      - name: Checkout
+        uses: actions/checkout@v3
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker meta
+        id: dockeraction # you'll use this in the next step
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            logzio/docker-collector-logs
+          flavor: |
+            latest=false
+          # Docker tags based on the following events/attributes
+
+      - name: Build and push amd64
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.dockeraction.outputs.tags }}-amd
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+
+      - name: Build and push amd64 latest
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: logzio/docker-collector-logs:latest-amd
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+      - name: Build and push arm64 latest
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.arm
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: logzio/docker-collector-logs:latest-arm
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+      - name: Build and push arm64
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.arm
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.dockeraction.outputs.tags }}-arm
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+      - name: Create manifest version
+        run: |
+          docker manifest create ${{ steps.dockeraction.outputs.tags }} --amend ${{ steps.dockeraction.outputs.tags }}-arm --amend ${{ steps.dockeraction.outputs.tags }}-amd
+
+      - name: Create manifest latest
+        run: |
+          docker manifest create logzio/docker-collector-logs:latest --amend logzio/docker-collector-logs:latest-arm --amend logzio/docker-collector-logs:latest-amd
+
+      - name: Push manifest latest
+        run: |
+          docker manifest push logzio/docker-collector-logs:latest
+      - name: Push manifest version
+        run: |
+          docker manifest push ${{ steps.dockeraction.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.0a2-alpine
 
-ENV PACKAGE=filebeat-7.12.1-linux-x86_64.tar.gz
+ENV PACKAGE=filebeat-8.3.3-linux-x86_64.tar.gz
 
 
 RUN mkdir -p /opt/filebeat/docker-colletor-logs && \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,6 +1,6 @@
 FROM python:3.11.0a2-alpine
 
-ENV PACKAGE=filebeat-7.12.1-linux-arm64.tar.gz
+ENV PACKAGE=filebeat-8.3.3-linux-arm64.tar.gz
 
 
 RUN mkdir -p /opt/filebeat/docker-colletor-logs && \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ logzio/docker-collector-logs
 | **multilineNegate**    | **Default** `'false'` <br> Insert `'true'` to negate the pattern. <br /> **Note**: Cannot be used without multilinePattern. See [Filebeat's official documentation](https://www.elastic.co/guide/en/beats/filebeat/7.12/multiline-examples.html#multiline) for further info.                                                                                                                                      |
 | **multilineMatch**     | **Default** `'after'` <br>  Specifies how Filebeat combines matching lines into an event. The settings are `after` or `before`. The behavior of these settings depends on what you specify for negate. <br /> **Note**: Cannot be used without multilinePattern. See [Filebeat's official documentation](https://www.elastic.co/guide/en/beats/filebeat/7.12/multiline-examples.html#multiline) for further info. |
 | **LOG_LEVEL**          | **Default** `info`. Set log level for the collector. Allowed values are: `debug`, `info`, `warning`, `error`.                                                                                                                                                                                                                                                                                                     |
+| **INPUT_ENCODING**     | **Default** `utf-8`. Here is a full list of [valid encodings](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-container.html#_encoding) you can use.                                                                                                                                                                                                                                        |
 
 
 **Note**: By default, logs from `docker-collector-logs` and `docker-collector-metrics` containers are ignored.
@@ -69,6 +70,8 @@ Spin up your Docker containers if you haven’t done so already. Give your logs 
 
 - 0.3.0:
   - Upgrade to Filebeat 8.3.3.
+  - Allow configuring encoding for input (`INPUT_ENCODING`).
+  - Remove print of version number.
 - 0.2.0:
   - Allow changing log level.
   - Upgrade base image to python 3.11.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Spin up your Docker containers if you haven’t done so already. Give your logs 
 
 ### Change log
 
+- 0.3.0:
+  - Upgrade to Filebeat 8.3.3.
 - 0.2.0:
   - Allow changing log level.
   - Upgrade base image to python 3.11.

--- a/default_filebeat.yml
+++ b/default_filebeat.yml
@@ -8,8 +8,7 @@ filebeat.inputs:
   paths:
     - '/var/lib/docker/containers/*/*.log'
   fields_under_root: true
-  encoding: utf-8
-  
+
 #The following processors are to ensure compatibility with version 7
 processors:
 - add_docker_metadata: ~

--- a/filebeat-yml-script.py
+++ b/filebeat-yml-script.py
@@ -21,7 +21,6 @@ def get_log_level():
 
 
 # set vars and consts
-DOCKER_COLLECTOR_VERSION = "0.2.0"
 LOGZIO_LISTENER_ADDRESS = "listener.logz.io:5015"
 PROCESSORS_AVAILABLE_INDEX = 3
 logzio_url = LOGZIO_LISTENER_ADDRESS
@@ -281,16 +280,11 @@ def _get_host_name():
     return os.getenv("HOSTNAME", '')
 
 
-def _display_docker_collector_version():
-    logging.info("Using docker-collector-logs version: {}".format(DOCKER_COLLECTOR_VERSION))
-
-
 _set_url()
 
 HOST = logzio_url_arr[0]
 PORT = int(logzio_url_arr[1])
 
-_display_docker_collector_version()
 _is_open()
 _add_shipping_data()
 

--- a/filebeat-yml-script.py
+++ b/filebeat-yml-script.py
@@ -32,7 +32,7 @@ logzio_type = os.getenv("LOGZIO_TYPE", "docker-collector-logs")
 logzio_region = os.getenv("LOGZIO_REGION", "")
 logzio_codec = os.getenv("LOGZIO_CODEC", "plain").lower()
 logzio_codec_list = ["plain", "json"]
-input_encoding = os.getenv("INPUT_ENCODING", "utf-8")
+input_encoding = os.getenv("INPUT_ENCODING", "utf-8").lower()
 if logzio_codec not in logzio_codec_list:
     logging.warning(f"LOGZIO_CODEC={logzio_codec} not supported. Make sure you use one of following: "
                     f"{logzio_codec_list}. Falling back to default LOGZIO_CODEC=plain")
@@ -90,6 +90,7 @@ def _is_open():
 
 def _add_shipping_data():
     yaml = YAML()
+    _validate_encoding()
     with open("docker-collector-logs/default_filebeat.yml") as default_filebeat_yml:
         config_dic = yaml.load(default_filebeat_yml)
 
@@ -280,6 +281,22 @@ def _add_multiline_type():
 
 def _get_host_name():
     return os.getenv("HOSTNAME", '')
+
+
+def _validate_encoding():
+    global input_encoding
+    # According to https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-container.html#_encoding
+    valid_encodings = ["plain", "utf-8", "utf8", "gbk", "iso8859-6e", "iso8859-6i", "iso8859-8e", "iso8859-8i",
+                       "iso8859-1", "iso8859-2", "iso8859-3", "iso8859-4", "iso8859-5", "iso8859-6", "iso8859-7",
+                       "iso8859-8", "iso8859-9", "iso8859-10", "iso8859-13", "iso8859-14", "iso8859-15", "iso8859-16",
+                       "cp437", "cp850", "cp852", "cp855", "cp858", "cp860", "cp862", "cp863", "cp865", "cp866",
+                       "ebcdic-037", "ebcdic-1040", "ebcdic-1047", "koi8r", "koi8u", "macintosh", "macintosh-cyrillic",
+                       "windows1250", "windows1251", "windows1252", "windows1253", "windows1254", "windows1255",
+                       "windows1256", "windows1257", "windows1258", "windows874", "utf-16-bom", "utf-16be-bom",
+                       "utf-16le-bom"]
+    if input_encoding not in valid_encodings:
+        logging.info(f"Your input_encoding {input_encoding} is invalid. Reverting to default utf-8")
+        input_encoding = "utf-8"
 
 
 _set_url()

--- a/filebeat-yml-script.py
+++ b/filebeat-yml-script.py
@@ -32,6 +32,7 @@ logzio_type = os.getenv("LOGZIO_TYPE", "docker-collector-logs")
 logzio_region = os.getenv("LOGZIO_REGION", "")
 logzio_codec = os.getenv("LOGZIO_CODEC", "plain").lower()
 logzio_codec_list = ["plain", "json"]
+input_encoding = os.getenv("INPUT_ENCODING", "utf-8")
 if logzio_codec not in logzio_codec_list:
     logging.warning(f"LOGZIO_CODEC={logzio_codec} not supported. Make sure you use one of following: "
                     f"{logzio_codec_list}. Falling back to default LOGZIO_CODEC=plain")
@@ -98,6 +99,7 @@ def _add_shipping_data():
     config_dic["filebeat.inputs"][0]["fields"]["logzio_codec"] = logzio_codec
     config_dic["filebeat.inputs"][0]["fields"]["type"] = logzio_type
     config_dic["filebeat.inputs"][0]["ignore_older"] = _get_ignore_older()
+    config_dic["filebeat.inputs"][0]["encoding"] = input_encoding
     config_dic["logging.level"] = log_level_filebeat
 
     hostname = _get_host_name()


### PR DESCRIPTION
- Upgrade from filebeat 7.12 to filebeat 8.3.3.
- Add workflow for building & pushing docker images.
- Update changelog.
- Remove from script print of version (unnecessary and prone to mistakes).